### PR TITLE
Catch http 409 error (empty repo)

### DIFF
--- a/rename_github_default_branch.py
+++ b/rename_github_default_branch.py
@@ -69,6 +69,9 @@ def rename_default_branch(
     if r.status_code == 404:
         logger.info(f"no branch named {current} on {repo_name}")
         return
+    elif r.status_code == 409:
+        logger.info(f"no branches found in empty repo {repo_name}")
+        return
     r.raise_for_status()
     sha = r.json()["object"]["sha"]
 


### PR DESCRIPTION
The script failed on an empty repo of mine, which returned a status code 409. It looks like that is the standard for an empty repo: https://developer.github.com/v3/git/