### PR TITLE
Use GH API to rename branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,3 @@ git branch -D master
 
 where `main` is the name of the new default branch and `origin` is the name of the git remote.
 
-### A note about pull requests
-
-This script *will not* change the target for open pull requests when the branch is renamed and open pull requests will continue to point at the branch that they were opened on.
-It is possible to change the target branch [in the user interface](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/changing-the-base-branch-of-a-pull-request) and it is possible that this could be automated using the API, but I have not experimented with that yet.
-


### PR DESCRIPTION
This updates the script to use GitHub's rename API.

Advantages of this include:
 - GitHub automatically updating open pull requests
 - GitHub displaying help info to repo visitors:
![github-branch-renamed-help-bubble](https://user-images.githubusercontent.com/813929/110434627-0423ed80-80ed-11eb-8517-fc111be9fb77.png)

Note: This change removes the option to keep the old branch, so the `--delete` flag is no longer recognised.